### PR TITLE
feat: add PWA install capability

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -36,6 +36,7 @@ a { color:var(--accent); text-decoration:none; }
 .menu { display:flex; gap:18px; }
 .menu a { padding:10px 12px; border-radius:8px; color:var(--text); }
 .menu a.active, .menu a:hover { background:rgba(56,189,248,.12); }
+#install-app{ display:none; }
 
 .burger { display:none; background:none; color:var(--text); font-size:22px; border:0; }
 

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -85,3 +85,30 @@ document.addEventListener("DOMContentLoaded", () => {
     music.volume = e.target.value;
   });
 });
+
+// ---------- PWA install
+(() => {
+  if ('serviceWorker' in navigator) {
+    window.addEventListener('load', () => {
+      navigator.serviceWorker.register('sw.js').catch(() => {});
+    });
+  }
+
+  let deferredPrompt;
+  const btn = document.getElementById('install-app');
+  if (!btn) return;
+
+  window.addEventListener('beforeinstallprompt', (e) => {
+    e.preventDefault();
+    deferredPrompt = e;
+    btn.style.display = 'inline-block';
+  });
+
+  btn.addEventListener('click', async () => {
+    if (!deferredPrompt) return;
+    deferredPrompt.prompt();
+    await deferredPrompt.userChoice;
+    deferredPrompt = null;
+    btn.style.display = 'none';
+  });
+})();

--- a/contact.html
+++ b/contact.html
@@ -9,6 +9,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="icon" href="assets/img/favicon.png" type="image/png">
+  <link rel="manifest" href="manifest.json">
   <link rel="stylesheet" href="assets/css/style.css">
   <script defer src="assets/js/script.js"></script>
 </head>
@@ -22,6 +23,7 @@
       <a href="services.html">Services</a>
       <a href="tarifs.html">Tarifs</a>
       <a href="contact.html" class="active">Contact</a>
+      <button id="install-app" class="btn ghost">Installer l'app</button>
     </nav>
   </div>
 </header>

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="icon" href="assets/img/favicon.png" type="image/png">
+  <link rel="manifest" href="manifest.json">
   <link rel="stylesheet" href="assets/css/style.css">
   <script defer src="assets/js/script.js"></script>
 </head>
@@ -26,6 +27,7 @@
       <a href="tarifs.html">Tarifs</a>
       <a href="market.html">Boutique</a>
       <a href="contact.html">Contact</a>
+      <button id="install-app" class="btn ghost">Installer l'app</button>
     </nav>
   </div>
 </header>

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,20 @@
+{
+  "name": "ALT-FIX",
+  "short_name": "ALT-FIX",
+  "start_url": "./index.html",
+  "display": "standalone",
+  "background_color": "#0b1220",
+  "theme_color": "#0b1220",
+  "icons": [
+    {
+      "src": "assets/img/favicon.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "assets/img/favicon.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}

--- a/merci.html
+++ b/merci.html
@@ -7,6 +7,8 @@
   <meta name="description" content="Merci pour votre message — ALT-FIX (Montage PC, dépannage, installation informatique Dijon/Genlis).">
   <link rel="stylesheet" href="assets/css/style.css">
   <link rel="icon" href="assets/img/favicon.png" type="image/png">
+  <link rel="manifest" href="manifest.json">
+  <script defer src="assets/js/script.js"></script>
 </head>
 <body>
 <header class="site-header">

--- a/services.html
+++ b/services.html
@@ -9,6 +9,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="icon" href="assets/img/favicon.png" type="image/png">
+  <link rel="manifest" href="manifest.json">
   <link rel="stylesheet" href="assets/css/style.css">
   <script defer src="assets/js/script.js"></script>
 </head>
@@ -22,6 +23,7 @@
       <a href="services.html" class="active">Services</a>
       <a href="tarifs.html">Tarifs</a>
       <a href="contact.html">Contact</a>
+      <button id="install-app" class="btn ghost">Installer l'app</button>
     </nav>
   </div>
 </header>

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,33 @@
+const CACHE_NAME = 'altfix-cache-v1';
+const ASSETS = [
+  '/',
+  '/index.html',
+  '/contact.html',
+  '/services.html',
+  '/tarifs.html',
+  '/merci.html',
+  '/assets/css/style.css',
+  '/assets/js/script.js',
+  '/assets/img/favicon.png',
+  '/assets/img/logo.svg'
+];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(ASSETS))
+  );
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(keys.filter((k) => k !== CACHE_NAME).map((k) => caches.delete(k)))
+    )
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  event.respondWith(
+    caches.match(event.request).then((response) => response || fetch(event.request))
+  );
+});

--- a/tarifs.html
+++ b/tarifs.html
@@ -9,6 +9,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="icon" href="assets/img/favicon.png" type="image/png">
+  <link rel="manifest" href="manifest.json">
   <link rel="stylesheet" href="assets/css/style.css">
   <script defer src="assets/js/script.js"></script>
 </head>
@@ -25,6 +26,7 @@
       <a href="services.html">Services</a>
       <a href="tarifs.html" class="active">Tarifs</a>
       <a href="contact.html">Contact</a>
+      <button id="install-app" class="btn ghost">Installer l'app</button>
     </nav>
   </div>
 </header>


### PR DESCRIPTION
## Summary
- add manifest and service worker to enable PWA install
- include install button in navigation
- register service worker and install prompt logic

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae294605e08324ba8f32251301175e